### PR TITLE
"Regenerate" -> "Rebuild"

### DIFF
--- a/read-only-plugins/mu-plugins/sandstorm.php
+++ b/read-only-plugins/mu-plugins/sandstorm.php
@@ -88,7 +88,7 @@ function sandstorm_publishing_info() {
   ?>
 
    <p>
-      To regenerate your public site, click the below button.
+      To rebuild your public site, click the below button.
       Note that you must click this button after making any changes
       in order for those changes to become visible on the public site.
    </p>
@@ -97,7 +97,7 @@ function sandstorm_publishing_info() {
    <p class="submit">
     <input type="hidden" name="action" value="generate_static">
    <?php wp_nonce_field( 'generate-static' ); ?>
-   <?php submit_button(__('Regenerate Public Site'), 'primary', 'generate', false); ?>
+   <?php submit_button(__('Rebuild Public Site'), 'primary', 'generate', false); ?>
    <br class="clear"/>
    </p>
   </form>

--- a/start.sh
+++ b/start.sh
@@ -9,7 +9,7 @@ mkdir -p /var/www
 cat > /var/www/index.html <<__EOF__
 <html><body>
 <p>This WordPress site has been set up successfully, but no content has
-been published. Go click the "Regenerate Public Site" button! </p>
+been published. Go click the "Rebuild Public Site" button! </p>
 </body></html>
 __EOF__
 


### PR DESCRIPTION
On IRC two nights ago, I mentioned that the "regenerate public site" language was confusing, as my first impression was that it would regenerate the *URL* of the site, not the site itself.  Here I propose changing the language to "rebuild public site", though it may be possible to come up with an even better term.